### PR TITLE
Supplier verification workflow (admin approve/reject)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,12 +12,14 @@
         "@prisma/client": "^7.2.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "nodemailer": "^8.0.5"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^25.0.7",
+        "@types/nodemailer": "^8.0.0",
         "@types/supertest": "^6.0.3",
         "nodemon": "^3.1.11",
         "prisma": "^7.2.0",
@@ -1288,6 +1290,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -3112,6 +3124,15 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,12 +18,14 @@
     "@prisma/client": "^7.2.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "nodemailer": "^8.0.5"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^25.0.7",
+    "@types/nodemailer": "^8.0.0",
     "@types/supertest": "^6.0.3",
     "nodemon": "^3.1.11",
     "prisma": "^7.2.0",

--- a/backend/prisma/migrations/20260410000000_supplier_verification_status/migration.sql
+++ b/backend/prisma/migrations/20260410000000_supplier_verification_status/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "VerificationStatus" AS ENUM ('UNVERIFIED', 'PENDING', 'VERIFIED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "Supplier"
+  ADD COLUMN "verificationStatus" "VerificationStatus" NOT NULL DEFAULT 'UNVERIFIED',
+  ADD COLUMN "verificationRejectedReason" TEXT;
+
+-- Migrate existing isVerified=true rows to VERIFIED
+UPDATE "Supplier" SET "verificationStatus" = 'VERIFIED' WHERE "isVerified" = true;
+
+-- DropColumn
+ALTER TABLE "Supplier" DROP COLUMN "isVerified";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,6 +21,13 @@ enum OrderStatus {
   CANCELLED
 }
 
+enum VerificationStatus {
+  UNVERIFIED
+  PENDING
+  VERIFIED
+  REJECTED
+}
+
 model User {
   id           String   @id @default(cuid())
   email        String   @unique
@@ -41,7 +48,8 @@ model Supplier {
   email        String   @unique
   passwordHash String
   address      String
-  isVerified   Boolean  @default(false)
+  verificationStatus         VerificationStatus @default(UNVERIFIED)
+  verificationRejectedReason String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,7 @@
 import cors, { type CorsOptions } from 'cors'
 import express from 'express'
+import { adminAuth } from './middleware/adminAuth.js'
+import adminRouter from './routes/admin.js'
 
 const app = express()
 
@@ -47,5 +49,7 @@ app.use(express.json())
 app.get('/', (_req, res) => {
   res.json({ status: 'ok' })
 })
+
+app.use('/admin', adminAuth, adminRouter)
 
 export default app

--- a/backend/src/lib/email.ts
+++ b/backend/src/lib/email.ts
@@ -1,0 +1,72 @@
+import nodemailer from 'nodemailer'
+
+function createTransport() {
+  const host = process.env['SMTP_HOST']
+  const port = parseInt(process.env['SMTP_PORT'] ?? '587', 10)
+  const user = process.env['SMTP_USER']
+  const pass = process.env['SMTP_PASS']
+
+  if (!host || !user || !pass) return null
+
+  return nodemailer.createTransport({
+    host,
+    port,
+    secure: port === 465,
+    auth: { user, pass },
+  })
+}
+
+const FROM = process.env['EMAIL_FROM'] ?? 'LocalSupply <noreply@localsupply.app>'
+
+export async function sendVerificationApproved(to: string, businessName: string): Promise<void> {
+  const transport = createTransport()
+  if (!transport) return
+
+  await transport.sendMail({
+    from: FROM,
+    to,
+    subject: 'Your supplier account has been approved',
+    text: [
+      `Hi ${businessName},`,
+      '',
+      'Your LocalSupply supplier account has been approved. You can now log in and start listing your products.',
+      '',
+      'Welcome aboard!',
+      'The LocalSupply Team',
+    ].join('\n'),
+    html: `
+      <p>Hi <strong>${businessName}</strong>,</p>
+      <p>Your LocalSupply supplier account has been <strong>approved</strong>. You can now log in and start listing your products.</p>
+      <p>Welcome aboard!<br>The LocalSupply Team</p>
+    `,
+  })
+}
+
+export async function sendVerificationRejected(to: string, businessName: string, reason: string): Promise<void> {
+  const transport = createTransport()
+  if (!transport) return
+
+  await transport.sendMail({
+    from: FROM,
+    to,
+    subject: 'Update on your LocalSupply supplier application',
+    text: [
+      `Hi ${businessName},`,
+      '',
+      'We reviewed your LocalSupply supplier application and were unable to approve it at this time.',
+      '',
+      `Reason: ${reason}`,
+      '',
+      'If you believe this was a mistake or would like to re-apply, please contact support.',
+      '',
+      'The LocalSupply Team',
+    ].join('\n'),
+    html: `
+      <p>Hi <strong>${businessName}</strong>,</p>
+      <p>We reviewed your LocalSupply supplier application and were unable to approve it at this time.</p>
+      <p><strong>Reason:</strong> ${reason}</p>
+      <p>If you believe this was a mistake or would like to re-apply, please contact support.</p>
+      <p>The LocalSupply Team</p>
+    `,
+  })
+}

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env['NODE_ENV'] !== 'production') {
+  globalForPrisma.prisma = prisma
+}

--- a/backend/src/middleware/adminAuth.ts
+++ b/backend/src/middleware/adminAuth.ts
@@ -1,0 +1,23 @@
+import type { NextFunction, Request, Response } from 'express'
+
+export function adminAuth(req: Request, res: Response, next: NextFunction): void {
+  const secret = process.env['ADMIN_SECRET']
+  if (!secret) {
+    res.status(503).json({ error: 'Admin access not configured' })
+    return
+  }
+
+  const authHeader = req.headers['authorization']
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' })
+    return
+  }
+
+  const token = authHeader.slice(7)
+  if (token !== secret) {
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+
+  next()
+}

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,109 @@
+import { Router } from 'express'
+import { sendVerificationApproved, sendVerificationRejected } from '../lib/email.js'
+import { prisma } from '../lib/prisma.js'
+
+type VerificationStatus = 'UNVERIFIED' | 'PENDING' | 'VERIFIED' | 'REJECTED'
+const VALID_STATUSES = new Set<string>(['UNVERIFIED', 'PENDING', 'VERIFIED', 'REJECTED'])
+
+const router = Router()
+
+// GET /admin/suppliers?status=PENDING
+router.get('/suppliers', async (req, res) => {
+  const rawStatus = req.query['status']
+  const status =
+    typeof rawStatus === 'string' && VALID_STATUSES.has(rawStatus)
+      ? (rawStatus as VerificationStatus)
+      : undefined
+
+  const suppliers = await prisma.supplier.findMany({
+    where: status ? { verificationStatus: status } : undefined,
+    select: {
+      id: true,
+      businessName: true,
+      contactName: true,
+      email: true,
+      phoneNumber: true,
+      address: true,
+      verificationStatus: true,
+      verificationRejectedReason: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  res.json(suppliers)
+})
+
+// POST /admin/suppliers/:id/approve
+router.post('/suppliers/:id/approve', async (req, res) => {
+  const { id } = req.params
+
+  const supplier = await prisma.supplier.findUnique({ where: { id } })
+  if (!supplier) {
+    res.status(404).json({ error: 'Supplier not found' })
+    return
+  }
+
+  const updated = await prisma.supplier.update({
+    where: { id },
+    data: {
+      verificationStatus: 'VERIFIED' as const,
+      verificationRejectedReason: null,
+    },
+    select: {
+      id: true,
+      businessName: true,
+      email: true,
+      verificationStatus: true,
+    },
+  })
+
+  await sendVerificationApproved(updated.email, updated.businessName)
+
+  res.json(updated)
+})
+
+// POST /admin/suppliers/:id/reject
+router.post('/suppliers/:id/reject', async (req, res) => {
+  const body = req.body as { reason?: unknown }
+  const reason = typeof body.reason === 'string' ? body.reason.trim() : ''
+
+  if (!reason) {
+    res.status(400).json({ error: 'A rejection reason is required' })
+    return
+  }
+
+  if (reason.length > 500) {
+    res.status(400).json({ error: 'Reason must be 500 characters or fewer' })
+    return
+  }
+
+  const { id } = req.params
+
+  const supplier = await prisma.supplier.findUnique({ where: { id } })
+  if (!supplier) {
+    res.status(404).json({ error: 'Supplier not found' })
+    return
+  }
+
+  const updated = await prisma.supplier.update({
+    where: { id },
+    data: {
+      verificationStatus: 'REJECTED' as const,
+      verificationRejectedReason: reason,
+    },
+    select: {
+      id: true,
+      businessName: true,
+      email: true,
+      verificationStatus: true,
+      verificationRejectedReason: true,
+    },
+  })
+
+  await sendVerificationRejected(updated.email, updated.businessName, reason)
+
+  res.json(updated)
+})
+
+export default router

--- a/backend/test/admin.test.ts
+++ b/backend/test/admin.test.ts
@@ -1,0 +1,134 @@
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import app from '../src/app.js'
+
+// Mock Prisma so tests don't need a real database
+vi.mock('../src/lib/prisma.js', () => ({
+  prisma: {
+    supplier: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+// Mock email so tests don't try to open SMTP connections
+vi.mock('../src/lib/email.js', () => ({
+  sendVerificationApproved: vi.fn(),
+  sendVerificationRejected: vi.fn(),
+}))
+
+import { prisma } from '../src/lib/prisma.js'
+
+const SECRET = 'test-admin-secret'
+
+beforeEach(() => {
+  process.env['ADMIN_SECRET'] = SECRET
+  vi.clearAllMocks()
+})
+
+describe('Admin auth middleware', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(app).get('/admin/suppliers')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when secret is wrong', async () => {
+    const res = await request(app).get('/admin/suppliers').set('Authorization', 'Bearer wrong')
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 503 when ADMIN_SECRET is not set', async () => {
+    delete process.env['ADMIN_SECRET']
+    const res = await request(app).get('/admin/suppliers').set('Authorization', `Bearer ${SECRET}`)
+    expect(res.status).toBe(503)
+  })
+})
+
+describe('GET /admin/suppliers', () => {
+  it('returns supplier list', async () => {
+    const mockSuppliers = [
+      {
+        id: 'sup1',
+        businessName: 'Farm Co',
+        contactName: 'Alice',
+        email: 'alice@farm.co',
+        phoneNumber: '555-0100',
+        address: '1 Farm Rd',
+        verificationStatus: 'PENDING',
+        verificationRejectedReason: null,
+        createdAt: new Date().toISOString(),
+      },
+    ]
+    vi.mocked(prisma.supplier.findMany).mockResolvedValue(mockSuppliers as never)
+
+    const res = await request(app).get('/admin/suppliers').set('Authorization', `Bearer ${SECRET}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(1)
+    expect(res.body[0].businessName).toBe('Farm Co')
+  })
+})
+
+describe('POST /admin/suppliers/:id/approve', () => {
+  it('approves a supplier and returns updated record', async () => {
+    const mockSupplier = { id: 'sup1', businessName: 'Farm Co', email: 'alice@farm.co' }
+    vi.mocked(prisma.supplier.findUnique).mockResolvedValue(mockSupplier as never)
+    vi.mocked(prisma.supplier.update).mockResolvedValue({
+      ...mockSupplier,
+      verificationStatus: 'VERIFIED',
+    } as never)
+
+    const res = await request(app).post('/admin/suppliers/sup1/approve').set('Authorization', `Bearer ${SECRET}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.verificationStatus).toBe('VERIFIED')
+  })
+
+  it('returns 404 for unknown supplier', async () => {
+    vi.mocked(prisma.supplier.findUnique).mockResolvedValue(null)
+    const res = await request(app).post('/admin/suppliers/unknown/approve').set('Authorization', `Bearer ${SECRET}`)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /admin/suppliers/:id/reject', () => {
+  it('rejects a supplier with a reason', async () => {
+    const mockSupplier = { id: 'sup1', businessName: 'Farm Co', email: 'alice@farm.co' }
+    vi.mocked(prisma.supplier.findUnique).mockResolvedValue(mockSupplier as never)
+    vi.mocked(prisma.supplier.update).mockResolvedValue({
+      ...mockSupplier,
+      verificationStatus: 'REJECTED',
+      verificationRejectedReason: 'Incomplete docs',
+    } as never)
+
+    const res = await request(app)
+      .post('/admin/suppliers/sup1/reject')
+      .set('Authorization', `Bearer ${SECRET}`)
+      .send({ reason: 'Incomplete docs' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.verificationStatus).toBe('REJECTED')
+    expect(res.body.verificationRejectedReason).toBe('Incomplete docs')
+  })
+
+  it('returns 400 when reason is missing', async () => {
+    const res = await request(app)
+      .post('/admin/suppliers/sup1/reject')
+      .set('Authorization', `Bearer ${SECRET}`)
+      .send({})
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 for unknown supplier', async () => {
+    vi.mocked(prisma.supplier.findUnique).mockResolvedValue(null)
+    const res = await request(app)
+      .post('/admin/suppliers/sup1/reject')
+      .set('Authorization', `Bearer ${SECRET}`)
+      .send({ reason: 'Bad actor' })
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -1,5 +1,14 @@
 import request from 'supertest'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/lib/prisma.js', () => ({
+  prisma: { supplier: { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn() } },
+}))
+vi.mock('../src/lib/email.js', () => ({
+  sendVerificationApproved: vi.fn(),
+  sendVerificationRejected: vi.fn(),
+}))
+
 import app from '../src/app.js'
 
 describe('GET /', () => {

--- a/frontend/src/app/admin/suppliers/page.tsx
+++ b/frontend/src/app/admin/suppliers/page.tsx
@@ -1,0 +1,5 @@
+import AdminSuppliersPage from '../../../features/pages/admin/AdminSuppliersPage'
+
+export default function Page() {
+  return <AdminSuppliersPage />
+}

--- a/frontend/src/features/pages/admin/AdminSuppliersPage.tsx
+++ b/frontend/src/features/pages/admin/AdminSuppliersPage.tsx
@@ -1,0 +1,390 @@
+'use client'
+
+import { type FormEvent, useCallback, useEffect, useState } from 'react'
+
+const API_BASE = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3000'
+
+type VerificationStatus = 'UNVERIFIED' | 'PENDING' | 'VERIFIED' | 'REJECTED'
+
+type Supplier = {
+  id: string
+  businessName: string
+  contactName: string
+  email: string
+  phoneNumber: string
+  address: string
+  verificationStatus: VerificationStatus
+  verificationRejectedReason: string | null
+  createdAt: string
+}
+
+const STATUS_LABELS: Record<VerificationStatus, string> = {
+  UNVERIFIED: 'Unverified',
+  PENDING: 'Pending',
+  VERIFIED: 'Verified',
+  REJECTED: 'Rejected',
+}
+
+const STATUS_STYLES: Record<VerificationStatus, string> = {
+  UNVERIFIED: 'bg-gray-100 text-gray-600',
+  PENDING: 'bg-yellow-100 text-yellow-700',
+  VERIFIED: 'bg-green-100 text-green-700',
+  REJECTED: 'bg-red-100 text-red-700',
+}
+
+const STATUS_FILTERS: Array<{ label: string; value: VerificationStatus | 'ALL' }> = [
+  { label: 'All', value: 'ALL' },
+  { label: 'Pending', value: 'PENDING' },
+  { label: 'Unverified', value: 'UNVERIFIED' },
+  { label: 'Verified', value: 'VERIFIED' },
+  { label: 'Rejected', value: 'REJECTED' },
+]
+
+function StatusBadge({ status }: { status: VerificationStatus }) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_STYLES[status]}`}>
+      {STATUS_LABELS[status]}
+    </span>
+  )
+}
+
+function RejectModal({
+  supplier,
+  onConfirm,
+  onCancel,
+}: {
+  supplier: Supplier
+  onConfirm: (reason: string) => void
+  onCancel: () => void
+}) {
+  const [reason, setReason] = useState('')
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const trimmed = reason.trim()
+    if (trimmed) onConfirm(trimmed)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <h3 className="text-lg font-semibold text-[#1b2a1f]">Reject supplier</h3>
+        <p className="mt-1 text-sm text-[#5b665f]">
+          Provide a reason for rejecting <strong>{supplier.businessName}</strong>. This will be emailed to the supplier.
+        </p>
+        <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
+          <label className="block space-y-1.5 text-sm font-medium text-[#374151]">
+            Rejection reason
+            <textarea
+              className="mt-1 w-full rounded-xl border border-[#d1d5db] px-3 py-2 text-sm text-[#1f2937] outline-none transition focus:border-[#2f9f4f] focus:ring-2 focus:ring-[#2f9f4f]/20"
+              maxLength={500}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="e.g. Incomplete business documentation, address could not be verified…"
+              required
+              rows={4}
+              value={reason}
+            />
+            <span className="block text-right text-xs text-[#9ca3af]">{reason.length}/500</span>
+          </label>
+          <div className="flex gap-3">
+            <button
+              className="flex-1 rounded-xl border border-[#d1d5db] px-4 py-2.5 text-sm font-medium text-[#374151] transition hover:bg-[#f9fafb]"
+              onClick={onCancel}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="flex-1 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-red-700 disabled:opacity-50"
+              disabled={!reason.trim()}
+              type="submit"
+            >
+              Reject supplier
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function SupplierRow({
+  supplier,
+  onApprove,
+  onReject,
+  actionPending,
+}: {
+  supplier: Supplier
+  onApprove: (id: string) => void
+  onReject: (supplier: Supplier) => void
+  actionPending: boolean
+}) {
+  const canAct = supplier.verificationStatus === 'PENDING' || supplier.verificationStatus === 'UNVERIFIED'
+
+  return (
+    <tr className="border-t border-[#e5e7eb] hover:bg-[#f9fafb]">
+      <td className="px-4 py-3">
+        <p className="font-medium text-[#1b2a1f]">{supplier.businessName}</p>
+        <p className="text-xs text-[#5b665f]">{supplier.contactName}</p>
+      </td>
+      <td className="px-4 py-3 text-sm text-[#374151]">{supplier.email}</td>
+      <td className="px-4 py-3 text-sm text-[#374151]">{supplier.phoneNumber}</td>
+      <td className="px-4 py-3 text-sm text-[#374151]">{supplier.address}</td>
+      <td className="px-4 py-3">
+        <StatusBadge status={supplier.verificationStatus} />
+        {supplier.verificationRejectedReason ? (
+          <p className="mt-1 max-w-[180px] text-xs text-red-600" title={supplier.verificationRejectedReason}>
+            {supplier.verificationRejectedReason.length > 60
+              ? supplier.verificationRejectedReason.slice(0, 60) + '…'
+              : supplier.verificationRejectedReason}
+          </p>
+        ) : null}
+      </td>
+      <td className="px-4 py-3 text-sm text-[#5b665f]">{new Date(supplier.createdAt).toLocaleDateString()}</td>
+      <td className="px-4 py-3">
+        {canAct ? (
+          <div className="flex gap-2">
+            <button
+              className="rounded-lg bg-[#2f9f4f] px-3 py-1.5 text-xs font-medium text-white transition hover:bg-[#25813f] disabled:opacity-50"
+              disabled={actionPending}
+              onClick={() => onApprove(supplier.id)}
+              type="button"
+            >
+              Approve
+            </button>
+            <button
+              className="rounded-lg border border-red-300 px-3 py-1.5 text-xs font-medium text-red-600 transition hover:bg-red-50 disabled:opacity-50"
+              disabled={actionPending}
+              onClick={() => onReject(supplier)}
+              type="button"
+            >
+              Reject
+            </button>
+          </div>
+        ) : (
+          <span className="text-xs text-[#9ca3af]">—</span>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+export default function AdminSuppliersPage() {
+  const [secret, setSecret] = useState('')
+  const [secretInput, setSecretInput] = useState('')
+  const [suppliers, setSuppliers] = useState<Supplier[]>([])
+  const [filter, setFilter] = useState<VerificationStatus | 'ALL'>('PENDING')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [actionPending, setActionPending] = useState(false)
+  const [rejectTarget, setRejectTarget] = useState<Supplier | null>(null)
+  const [toast, setToast] = useState('')
+
+  function showToast(msg: string) {
+    setToast(msg)
+    setTimeout(() => setToast(''), 3500)
+  }
+
+  const fetchSuppliers = useCallback(
+    async (currentSecret: string, status: VerificationStatus | 'ALL') => {
+      setLoading(true)
+      setError('')
+      try {
+        const url =
+          status === 'ALL' ? `${API_BASE}/admin/suppliers` : `${API_BASE}/admin/suppliers?status=${status}`
+        const res = await fetch(url, {
+          headers: { Authorization: `Bearer ${currentSecret}` },
+        })
+        if (res.status === 401 || res.status === 403) {
+          setError('Invalid admin secret.')
+          setSecret('')
+          return
+        }
+        if (!res.ok) throw new Error(`Server error ${res.status}`)
+        setSuppliers((await res.json()) as Supplier[])
+      } catch {
+        setError('Failed to load suppliers. Check your network and try again.')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (secret) {
+      void fetchSuppliers(secret, filter)
+    }
+  }, [secret, filter, fetchSuppliers])
+
+  async function handleApprove(id: string) {
+    setActionPending(true)
+    try {
+      const res = await fetch(`${API_BASE}/admin/suppliers/${id}/approve`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${secret}` },
+      })
+      if (!res.ok) throw new Error()
+      showToast('Supplier approved and notified.')
+      await fetchSuppliers(secret, filter)
+    } catch {
+      setError('Failed to approve supplier.')
+    } finally {
+      setActionPending(false)
+    }
+  }
+
+  async function handleRejectConfirm(reason: string) {
+    if (!rejectTarget) return
+    const { id } = rejectTarget
+    setRejectTarget(null)
+    setActionPending(true)
+    try {
+      const res = await fetch(`${API_BASE}/admin/suppliers/${id}/reject`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${secret}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason }),
+      })
+      if (!res.ok) throw new Error()
+      showToast('Supplier rejected and notified.')
+      await fetchSuppliers(secret, filter)
+    } catch {
+      setError('Failed to reject supplier.')
+    } finally {
+      setActionPending(false)
+    }
+  }
+
+  if (!secret) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#f7faf5] px-4">
+        <div className="w-full max-w-sm rounded-2xl border border-[#dfe5da] bg-white p-8 shadow-lg">
+          <h1 className="text-xl font-bold text-[#1b2a1f]">Admin access</h1>
+          <p className="mt-1 text-sm text-[#5b665f]">Enter the admin secret to continue.</p>
+          <form
+            className="mt-6 space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault()
+              setSecret(secretInput.trim())
+            }}
+          >
+            <label className="block space-y-1.5 text-sm font-medium text-[#374151]">
+              Admin secret
+              <input
+                autoComplete="current-password"
+                className="mt-1 w-full rounded-xl border border-[#d1d5db] px-3 py-2.5 text-sm outline-none transition focus:border-[#2f9f4f] focus:ring-2 focus:ring-[#2f9f4f]/20"
+                onChange={(e) => setSecretInput(e.target.value)}
+                placeholder="Enter secret"
+                required
+                type="password"
+                value={secretInput}
+              />
+            </label>
+            <button
+              className="w-full rounded-xl bg-[#2f9f4f] px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-[#25813f]"
+              type="submit"
+            >
+              Sign in
+            </button>
+          </form>
+        </div>
+      </main>
+    )
+  }
+
+  const pendingCount = suppliers.filter((s) => s.verificationStatus === 'PENDING').length
+
+  return (
+    <main className="min-h-screen bg-[#f7faf5] px-4 py-8">
+      {toast ? (
+        <div className="fixed right-4 top-4 z-40 rounded-xl bg-[#1b2a1f] px-4 py-3 text-sm text-white shadow-lg">
+          {toast}
+        </div>
+      ) : null}
+
+      {rejectTarget ? (
+        <RejectModal
+          onCancel={() => setRejectTarget(null)}
+          onConfirm={(reason) => void handleRejectConfirm(reason)}
+          supplier={rejectTarget}
+        />
+      ) : null}
+
+      <div className="mx-auto max-w-7xl">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-[#1b2a1f]">Supplier verification</h1>
+            {pendingCount > 0 ? (
+              <p className="mt-0.5 text-sm text-[#5b665f]">
+                {pendingCount} supplier{pendingCount !== 1 ? 's' : ''} awaiting review
+              </p>
+            ) : null}
+          </div>
+          <button
+            className="rounded-xl border border-[#dfe5da] bg-white px-4 py-2 text-sm font-medium text-[#374151] transition hover:bg-[#f0f5ee]"
+            onClick={() => void fetchSuppliers(secret, filter)}
+            type="button"
+          >
+            Refresh
+          </button>
+        </div>
+
+        <div className="mt-6 flex gap-2">
+          {STATUS_FILTERS.map(({ label, value }) => (
+            <button
+              key={value}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
+                filter === value
+                  ? 'bg-[#2f9f4f] text-white'
+                  : 'bg-white text-[#374151] border border-[#dfe5da] hover:bg-[#f0f5ee]'
+              }`}
+              onClick={() => setFilter(value)}
+              type="button"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        ) : null}
+
+        <div className="mt-4 overflow-hidden rounded-2xl border border-[#dfe5da] bg-white shadow-sm">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-sm text-[#5b665f]">Loading…</div>
+          ) : suppliers.length === 0 ? (
+            <div className="px-6 py-12 text-center text-sm text-[#5b665f]">No suppliers found for this filter.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-[#f7faf5] text-left text-xs font-semibold uppercase tracking-wide text-[#5b665f]">
+                    <th className="px-4 py-3">Business</th>
+                    <th className="px-4 py-3">Email</th>
+                    <th className="px-4 py-3">Phone</th>
+                    <th className="px-4 py-3">Address</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Applied</th>
+                    <th className="px-4 py-3">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {suppliers.map((supplier) => (
+                    <SupplierRow
+                      actionPending={actionPending}
+                      key={supplier.id}
+                      onApprove={(id) => void handleApprove(id)}
+                      onReject={setRejectTarget}
+                      supplier={supplier}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- **Schema**: replaces `isVerified: Boolean` on `Supplier` with a `VerificationStatus` enum (`UNVERIFIED` / `PENDING` / `VERIFIED` / `REJECTED`) and an optional `verificationRejectedReason` text field; migration preserves existing verified rows
- **Backend**: three admin-only endpoints protected by `ADMIN_SECRET` Bearer token — list suppliers by status, approve a supplier, reject a supplier with a reason; email sent to supplier on both status changes via nodemailer (no-ops gracefully if SMTP env vars are absent)
- **Frontend**: admin dashboard at `/admin/suppliers` with secret-gated login, status filter tabs, approve/reject buttons, rejection-reason modal, and toast notifications

## Environment variables required

| Variable | Purpose |
|---|---|
| `ADMIN_SECRET` | Bearer token for all `/admin/*` endpoints |
| `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` | SMTP credentials for outbound email |
| `EMAIL_FROM` | From address (defaults to `LocalSupply <noreply@localsupply.app>`) |
| `NEXT_PUBLIC_API_URL` | Backend URL for the frontend (defaults to `http://localhost:3000`) |

## Test plan

- [x] `npm test` in `backend/` — 10 tests passing (auth middleware, list, approve, reject)
- [ ] Run `prisma migrate deploy` against staging DB to apply the schema change
- [ ] Set `ADMIN_SECRET` on the backend deployment
- [ ] Verify supplier list loads at `/admin/suppliers` with correct Bearer token
- [ ] Approve a pending supplier — confirm status changes to `VERIFIED` and email is sent
- [ ] Reject a pending supplier with a reason — confirm status changes to `REJECTED`, reason stored, email sent
- [ ] Confirm wrong secret returns 401/403